### PR TITLE
Unify & clean up views

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -4,29 +4,30 @@
     <div class="container main-content">
         <div class="columns">
             <div class="column is-three-quarters">
-
                 <nav class="level">
                     <div class="level-left">
                         <div class="level-item">
                             <button class="button filter-questions is-primary">Filter &nbsp;<i class="fa fa-2X fa-caret-down"></i></button>
                         </div>
                     </div>
+
                     <div class="level-right">
                         <div class="level-item">
-                            <a href="{{route('post.create')}}" class="button ask-question is-pulled-right is-primary">Ask question</a>
+                            <a href="{{ route('post.create') }}" class="button ask-question is-pulled-right is-primary">Ask question</a>
                         </div>
                     </div>
                 </nav>
+
                 <nav class="panel filter-panel">
                     <p class="panel-heading">
                         Filter
                     </p>
+
                     <div class="level">
                         <div class="level-left">
                             <div class="panel-block level-item">
                                 <div class="field has-addons">
-                                    <form action="{{action('PostController@search')}}">
-
+                                    <form action="{{ action('PostController@search') }}">
                                         <p class="control" style="display: flex">
                                             <input name="query" class="input is-pulled-left" type="text" placeholder="Search">
                                             <button type="submit" class="button is-info is-pulled-left">
@@ -37,32 +38,25 @@
                                 </div>
                             </div>
                         </div>
+
                         <div class="level-right">
                             <div class="panel-block level-item">
                                 <div class="field is-horizontal">
                                     <div class="field-body">
                                         <div class="field">
-                                            <form id="search-tags" action="{{action('PostController@filter')}}">
-                                            <p class="control">
-                                                @foreach($tags as $tag)
-                                                    <label for=""  class="checkbox">
-                                                        <input name="tags[]" type="checkbox" value="{{$tag->id}}"
-                                                            <?php
-                                                                if (isset($searchTags))
-                                                                    {
-                                                                        if (in_array($tag->id, $searchTags))
-                                                                        {
-                                                                            echo 'checked';
-                                                                        }
-                                                                    }
-
-                                                            ?>
-                                                        >{{$tag->name}}
-                                                    </label>
-                                                @endforeach
-                                            </p>
+                                            <form id="search-tags" action="{{ action('PostController@filter') }}">
+                                                <p class="control">
+                                                    @foreach($tags as $tag)
+                                                        <label for="" class="checkbox">
+                                                            <input name="tags[]" type="checkbox" value="{{ $tag->id }}"
+                                                                   @if(isset($searchTags) && in_array($tag->id, $searchTags))
+                                                                       checked
+                                                                   @endif
+                                                            >{{ $tag->name }}
+                                                        </label>
+                                                    @endforeach
+                                                </p>
                                             </form>
-                                            </p>
                                         </div>
                                     </div>
                                 </div>
@@ -70,12 +64,11 @@
                         </div>
                     </div>
                 </nav>
-                @include('partials/_posts')
+
+                @include('partials._posts')
             </div>
 
             @include('partials._sidebar')
-
         </div>
-
     </div>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -25,22 +25,23 @@
 </head>
 <body>
     <div id="app">
-
         <nav class="nav has-shadow">
             <div class="container">
                 <div class="nav-left">
                     <a href="{{ route('home') }}" class="nav-item">
                         <img src="{{ asset('img/rc-fc.png') }}" alt="">
                     </a>
-                    <a href="{{action('HomeController@index')}}" class="nav-item is-tab is-hidden-mobile {{ strpos(Request::path(), 'home') === true ? 'is-active' : ''}}">Forum</a>
-                    <a href="{{action('HomeController@learn')}}" class="nav-item is-tab is-hidden-mobile {{ strpos(Request::path(), 'learn') === true ? 'is-active' : ''}} ">Learn</a>
+                    <a href="{{ action('HomeController@index') }}" class="nav-item is-tab is-hidden-mobile {{ strpos(Request::path(), 'home') === true ? 'is-active' : ''}}">Forum</a>
+                    <a href="{{ action('HomeController@learn') }}" class="nav-item is-tab is-hidden-mobile {{ strpos(Request::path(), 'learn') === true ? 'is-active' : ''}} ">Learn</a>
                     <a class="nav-item is-tab is-hidden-mobile">About</a>
                 </div>
-    <span class="nav-toggle">
-      <span></span>
-      <span></span>
-      <span></span>
-    </span>
+
+                <span class="nav-toggle">
+                    <span></span>
+                    <span></span>
+                    <span></span>
+                </span>
+
                 <div class="nav-right nav-menu">
                     <a class="nav-item is-tab is-hidden-tablet is-active">Home</a>
 
@@ -60,7 +61,6 @@
                            document.getElementById('logout-form').submit();">
                             Logout
                         </a>
-
                     @endif
 
                     <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
@@ -73,12 +73,12 @@
         <section class="hero banner">
             <div class="hero-body">
                 <div class="container">
-                    <img src="{{asset('img/logo.png')}}" class="is-pulled-right" alt="">
+                    <img src="{{ asset('img/logo.png') }}" class="is-pulled-right" alt="">
                 </div>
             </div>
         </section>
 
-        @include('partials/minis/_notifications')
+        @include('partials.minis._notifications')
 
         @yield('content')
     </div>
@@ -89,12 +89,15 @@
                 <div class="column">
                     <h3 class="is-3 is-title">Contribute to AmoHub!</h3>
                     <div class="level">
-                        <img class="level-item" width="40%" src="{{asset('img/rc-fc.png')}}" alt="">
-                        <img class="level-item" width="30%" src="{{asset('img/logo.png')}}" alt="">
+                        <img class="level-item" width="40%" src="{{ asset('img/rc-fc.png') }}" alt="">
+                        <img class="level-item" width="30%" src="{{ asset('img/logo.png') }}" alt="">
                     </div>
-                    <p>This is an open source project created for ROC West-Brabant. As a student, if you want to contribute, please check out the project on
-                        <a href="http://www.github.com/Radiuscollege/knb"> github</a>.</p>
+                    <p>
+                        This is an open source project created for ROC West-Brabant. As a student, if you want to contribute, please check out the project on
+                        <a href="https://github.com/Radiuscollege/knb">GitHub</a>.
+                    </p>
                 </div>
+
                 <div class="column"></div>
                 <div class="column"></div>
                 <div class="column"></div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -29,7 +29,7 @@
         <nav class="nav has-shadow">
             <div class="container">
                 <div class="nav-left">
-                    <a href="" class="nav-item">
+                    <a href="{{ route('home') }}" class="nav-item">
                         <img src="{{ asset('img/rc-fc.png') }}" alt="">
                     </a>
                     <a href="{{action('HomeController@index')}}" class="nav-item is-tab is-hidden-mobile {{ strpos(Request::path(), 'home') === true ? 'is-active' : ''}}">Forum</a>

--- a/resources/views/learn/detail.blade.php
+++ b/resources/views/learn/detail.blade.php
@@ -1,8 +1,7 @@
 @extends('layouts/app')
 
-
 @section('content')
     <div id="learning">
-        <videos tag="{{$tag}}"></videos>
+        <videos tag="{{ $tag }}"></videos>
     </div>
 @endsection

--- a/resources/views/learn/index.blade.php
+++ b/resources/views/learn/index.blade.php
@@ -1,6 +1,5 @@
 @extends('layouts/app')
 
-
 @section('content')
     <div id="learning">
         <videos-overview></videos-overview>

--- a/resources/views/partials/_create-comment.blade.php
+++ b/resources/views/partials/_create-comment.blade.php
@@ -3,22 +3,26 @@
         <p class="image is-64x64">
             <img src="http://bulma.io/images/placeholders/128x128.png">
         </p>
-        <p class="user-name">{{Auth::user()->name}}</p>
+        <p class="user-name">{{ Auth::user()->name }}</p>
     </figure>
+
     <div class="media-content">
         <form method="post" action="{{ action('CommentController@store') }}" id="comment-form">
             {{ csrf_field() }}
+
             <input type="hidden" name="post_id" value="{{ $post->id }}">
-        <div class="field">
-            <p class="control">
-                <textarea class="textarea" name="content" placeholder="Add a comment..."></textarea>
-            </p>
-        </div>
-        <div class="field">
-            <p class="control">
-                <button type="submit" class="button add-comment">Post comment</button>
-            </p>
-        </div>
+
+            <div class="field">
+                <p class="control">
+                    <textarea class="textarea" name="content" placeholder="Add a comment..."></textarea>
+                </p>
+            </div>
+
+            <div class="field">
+                <p class="control">
+                    <button type="submit" class="button add-comment">Post comment</button>
+                </p>
+            </div>
         </form>
     </div>
 </article>

--- a/resources/views/partials/_post.blade.php
+++ b/resources/views/partials/_post.blade.php
@@ -1,64 +1,69 @@
 @php ($question = $post)
 
 <div class="content">
-        <article class="media ">
-            <figure class="media-type media-left media-question">
-                <img src="{{asset('img/icons/question.png')}}" alt="">
+    <article class="media ">
+        <figure class="media-type media-left media-question">
+            <img src="{{ asset('img/icons/question.png') }}" alt="">
+        </figure>
 
-            </figure>
-
-            <div class="media-content">
-                <div class="content  media-post">
-                    <div class="box-options">
-                        @if($question->isYours())
-                            <a href="{{action('PostController@edit', $post->id)}}" class="option-edit">
-                                <i class="fa fa-2x fa-edit"></i>
-                            </a>
-                        @endif
-                        @unless($question->isYours())
-                        <a href="{{action('PostController@edit', $post->id)}}" class="option-flag">
+        <div class="media-content">
+            <div class="content media-post">
+                <div class="box-options">
+                    @if($question->isYours())
+                        <a href="{{ action('PostController@edit', $post) }}" class="option-edit">
+                            <i class="fa fa-2x fa-edit"></i>
+                        </a>
+                    @else
+                        <a href="{{ action('PostController@edit', $post) }}" class="option-flag">
                             <i class="fa fa-2x fa-flag"></i>
                         </a>
-                        @endunless
-                    </div>
-                    <p>
-                        <strong>{{ $post->author->name }}</strong>
-                    </p>
-                    <h4 class="title is-4">{{ $post->title }}</h4>
-                    <p>{!! $post->content !!}
-                    </p>
-                    <div class="level post-tags">
-                        <div class="level-left">
-                            @foreach($post->tags as $tag)
-                                @if($tag->thumbnail)
-                                    <div class="level-item">
-                                        <figure class="image is-32x32">
-                                            <img title="{{$tag->name}}" src="{{asset('img/icons/languages/')}}/{{$tag->thumbnail}}" alt="{{$tag->name}}">
-                                        </figure>
-                                    </div>
-                                @endif
-                            @endforeach
-                        </div>
-                        <div class="level-right">
-                            <p class="level-item">
-                               <i> created {{$post->getTimePosted()}} </i>
-                            </p>
-                        </div>
-                    </div>
-                    <div class="button-group">
+                    @endif
+                </div>
 
-                        @unless($post->isYours())
-                            <a href="{{action('PostController@answer', $post->id)}}" class="button is-success">Give answer</a>
-                        @endunless
-                        <a href="" class="btn-add-comment button is-info">Add comment</a>
-                           @include('partials/minis/_vote-group')
+                <p>
+                    <strong>{{ $post->author->name }}</strong>
+                </p>
+
+                <h4 class="title is-4">{{ $post->title }}</h4>
+                <p>{!! $post->content !!}</p>
+
+                <div class="level post-tags">
+                    <div class="level-left">
+                        @foreach($post->tags as $tag)
+                            @if($tag->thumbnail)
+                                <div class="level-item">
+                                    <figure class="image is-32x32">
+                                        <img title="{{ $tag->name }}" src="{{ asset('img/icons/languages/') }}/{{ $tag->thumbnail }}" alt="{{ $tag->name }}">
+                                    </figure>
+                                </div>
+                            @endif
+                        @endforeach
                     </div>
-                    <div class="form-comment-hidden">
-                        @include('partials/_create-comment')
+
+                    <div class="level-right">
+                        <p class="level-item">
+                           <i> created {{ $post->getTimePosted() }} </i>
+                        </p>
                     </div>
-                    <h3 class="is-3">{{ count($post->comments) }} {{str_plural('comment', count($post->comments))}}</h3>
-                    <div class="comment-box">
-                        @foreach($post->comments as $comment)
+                </div>
+
+                <div class="button-group">
+                    @unless($post->isYours())
+                        <a href="{{ action('PostController@answer', $post) }}" class="button is-success">Give answer</a>
+                    @endunless
+
+                    <a href="" class="btn-add-comment button is-info">Add comment</a>
+
+                    @include('partials.minis._vote-group')
+                </div>
+
+                <div class="form-comment-hidden">
+                    @include('partials._create-comment')
+                </div>
+
+                <h3 class="is-3">{{ $post->comments->count() }} {{ str_plural('comment', $post->comments->count()) }}</h3>
+                <div class="comment-box">
+                    @foreach($post->comments as $comment)
                         <article class="media">
                             <div class="content media-post-comment">
                                 <strong>{{ $comment->author->name }}</strong>
@@ -66,64 +71,69 @@
                                 <p>{!! nl2br($comment->content) !!}</p>
                             </div>
                         </article>
-                        @endforeach
-                    </div>
+                    @endforeach
                 </div>
-                <h2 class="is-2">{{ count($replies) }} Answers</h2>
-                @foreach($replies as $post)
+            </div>
+
+            <h2 class="is-2">{{ count($replies) }} Answers</h2>
+
+            @foreach($replies as $post)
                 <article class="media">
                     @if ($post->accepted_answer)
-                    <figure class="media-type media-accepted media-left">
-                        <img src="{{ asset('img/icons/accepted.png') }}" alt="">
-                    </figure>
+                        <figure class="media-type media-accepted media-left">
+                            <img src="{{ asset('img/icons/accepted.png') }}" alt="">
+                        </figure>
                     @else
-                    <figure class="media-type media-answer media-left">
-                        <img src="{{ asset('img/icons/answer.png') }}" alt="">
-                    </figure>
+                        <figure class="media-type media-answer media-left">
+                            <img src="{{ asset('img/icons/answer.png') }}" alt="">
+                        </figure>
                     @endif
-                    <div class="media-content">
 
+                    <div class="media-content">
                         <div class="content media-post">
                             <div class="box-options">
                                 @if($post->isYours())
-                                <a href="{{action('PostController@editAnswer', $post->id)}}" class="option-edit">
-                                    <i class="fa fa-edit fa-2x"></i>
-                                </a>
+                                    <a href="{{ action('PostController@editAnswer', $post) }}" class="option-edit">
+                                        <i class="fa fa-edit fa-2x"></i>
+                                    </a>
+                                @else
+                                    <a href="{{action('PostController@edit', $post->id) }}" class="option-flag">
+                                        <i class="fa fa-2x fa-flag"></i>
+                                    </a>
                                 @endif
-                                @unless($post->isYours())
-                                <a href="{{action('PostController@edit', $post->id)}}" class="option-flag">
-                                    <i class="fa fa-2x fa-flag"></i>
-                                </a>
-                                @endunless
                             </div>
+
                             <p>
                                 <strong>{{ $post->author->name }}</strong>
                             </p>
-                            <p>
-                               {!! $post->content !!}
-                            </p>
+
+                            <p>{!! $post->content !!}</p>
+
                             <div class="level post-tags">
                                 <div class="level-left">
                                     @foreach($post->tags as $tag)
                                         @if($tag->thumbnail)
                                             <div class="level-item">
                                                 <figure class="image is-32x32">
-                                                    <img title="{{$tag->name}}" src="{{asset('img/icons/languages/')}}/{{$tag->thumbnail}}" alt="{{$tag->name}}">
+                                                    <img title="{{ $tag->name }}" src="{{ asset('img/icons/languages/') }}/{{ $tag->thumbnail }}" alt="{{ $tag->name }}">
                                                 </figure>
                                             </div>
                                         @endif
                                     @endforeach
                                 </div>
+
                                 <div class="level-right">
                                     <p class="level-item">
-                                        <i> created {{$post->getTimePosted()}} </i>
+                                        <i> created {{ $post->getTimePosted() }} </i>
                                     </p>
                                 </div>
                             </div>
+
                             @if($question->isYours())
-                                <form method="POST" action="{{action('PostController@accept', $post->id)}}">
+                                <form method="POST" action="{{ action('PostController@accept', $post) }}">
                                     {{ csrf_field() }}
                                     <input type="hidden" name="_method" value="put">
+
                                     @if ($post->accepted_answer)
                                         <button type="submit" class="button is-warning" value="0" name="accepted">Cancel acceptation</button>
                                     @elseif(! $question->isAccepted())
@@ -134,11 +144,13 @@
 
                             <div class="button-group">
                                 <a href="" class="btn-add-comment button is-info">Add comment</a>
-                                @include('partials/minis/_vote-group')
+                                @include('partials.minis._vote-group')
                             </div>
+
                             <div class="form-comment-hidden">
-                                @include('partials/_create-comment')
+                                @include('partials._create-comment')
                             </div>
+
                             <div class="comment-box">
                                 @foreach($post->comments as $comment)
                                     <article class="media">
@@ -146,20 +158,14 @@
                                             <strong>{{ $comment->author->name }}</strong>
 
                                             <p>{!! nl2br($comment->content) !!}</p>
-
                                         </div>
                                     </article>
                                 @endforeach
                             </div>
-
-
                         </div>
-
-
                     </div>
                 </article>
-                @endforeach
-
-            </div>
-        </article>
-    </div>
+            @endforeach
+        </div>
+    </article>
+</div>

--- a/resources/views/partials/_posts.blade.php
+++ b/resources/views/partials/_posts.blade.php
@@ -1,64 +1,66 @@
 <div class="content">
-        @if(\Request::path() == 'post/search')
-            <p>You've searched for: <b>{{$query}}</b>. (<a href="{{action('HomeController@index')}}">reset</a>)</p>
-        @endif
-        <h1> Questions </h1>
-        <div class="posts" >
-            @foreach($posts as $post)
-            <div class="box box-post" data-href="{{action('PostController@show', $post->id)}}">
-                @if( \Auth::user()->isHeadMaster() )
+    @if(\Request::path() == 'post/search')
+        <p>You've searched for: <b>{{ $query }}</b>. (<a href="{{ action('HomeController@index') }}">reset</a>)</p>
+    @endif
+
+    <h1> Questions </h1>
+
+    <div class="posts" >
+        @foreach($posts as $post)
+            <div class="box box-post" data-href="{{ action('PostController@show', $post) }}">
+                @if(\Auth::user()->isHeadMaster())
                     @include("partials/minis/_post-admin-controls")
                 @endif
+
                 <div class="box-options">
                     @if($post->isYours())
-                    <a href="{{action('PostController@edit', $post->id)}}" class="option-edit">
-                        <i title="edit this post" class="fa fa-2x fa-edit"></i>
-                    </a>
-                    @endif
-                    @unless($post->isYours())
+                        <a href="{{ action('PostController@edit', $post) }}" class="option-edit">
+                            <i title="edit this post" class="fa fa-2x fa-edit"></i>
+                        </a>
+                    @else
                         @unless($post->isFlagged())
-                        <i class="option-flag">
-                            <i title="flag this post" class="fa fa-2x fa-flag"></i>
-                        </i>
-                            <form class="flag-form" style="display:none" action="{{action('PostController@flag', $post->id)}}" method="POST">
-                                {{csrf_field()}}
+                            <i class="option-flag">
+                                <i title="flag this post" class="fa fa-2x fa-flag"></i>
+                            </i>
+
+                            <form class="flag-form" style="display:none" action="{{ action('PostController@flag', $post) }}" method="POST">
+                                {{ csrf_field() }}
                             </form>
                         @else
                             <i title="this post is flagged. A moderator will look into this soon." style="color: red">
                                 flagged
                             </i>
                         @endunless
-                    @endunless
+                    @endif
                 </div>
+
                 <article class="media" >
+                    <figure class="media-left">
+                        <p class="image is-64x64">
+                            <img src="http://bulma.io/images/placeholders/128x128.png">
+                        </p>
 
-
-                        <figure class="media-left">
-                            <p class="image is-64x64">
-                                <img src="http://bulma.io/images/placeholders/128x128.png">
-                            </p>
-
-                        </figure>
+                    </figure>
 
                     <div class="media-content">
                         <div class="content">
                             <p>
                                 <strong>{{ $post->author->name }}</strong>
                                 <br>
-                                <a href="{{action('PostController@show', $post->id)}}">{{ $post->title }}</a>
+                                <a href="{{ action('PostController@show', $post) }}">{{ $post->title }}</a>
                             </p>
 
                         </div>
                         <div class="block">
-                        <a href="{{action('PostController@show', $post->id)}}" class="button">{{ $post->views }} {{ str_plural('view', $post->views) }}</a>
-                        <a href="{{action('PostController@show', $post->id)}}" class="button @if($post->isAccepted()) is-success @endif">
-                        @unless($post->isAccepted())
-                        {{ $post->getAnswerTotal() }}  {{ str_plural('answer', $post->getAnswerTotal()) }}
-                        @else
-                        accepted
-                        @endunless
-                        </a>
-                        <a href="{{action('PostController@show', $post->id)}}" class="button"> {{$post->getVotesTotal() }} Points </a>
+                            <a href="{{ action('PostController@show', $post) }}" class="button">{{ $post->views }} {{ str_plural('view', $post->views) }}</a>
+                            <a href="{{ action('PostController@show', $post) }}" class="button {{ $post->isAccepted() ? 'is-success' : '' }}">
+                                @unless($post->isAccepted())
+                                    {{ $post->getAnswerTotal() }} {{ str_plural('answer', $post->getAnswerTotal()) }}
+                                @else
+                                    accepted
+                                @endunless
+                            </a>
+                            <a href="{{ action('PostController@show', $post) }}" class="button"> {{ $post->getVotesTotal() }} Points </a>
                         </div>
                     </div>
                 </article>
@@ -67,24 +69,24 @@
                     <div class="level-left">
                         @foreach($post->tags as $tag)
                             @if($tag->thumbnail)
-                            <div class="level-item">
-                                <figure class="image is-32x32">
-                                    <img title="{{$tag->name}}" src="{{asset('img/icons/languages/')}}/{{$tag->thumbnail}}" alt="{{$tag->name}}">
-                                </figure>
-                            </div>
+                                <div class="level-item">
+                                    <figure class="image is-32x32">
+                                        <img title="{{ $tag->name }}" src="{{ asset('img/icons/languages/') }}/{{ $tag->thumbnail }}" alt="{{ $tag->name }}">
+                                    </figure>
+                                </div>
                             @endif
                         @endforeach
                     </div>
+
                     <div class="level-right">
                         <p class="level-item">
-                           created {{$post->getTimePosted()}}
+                           created {{ $post->getTimePosted() }}
                         </p>
                     </div>
                 </div>
             </div>
-            @endforeach
+        @endforeach
 
-            {{$posts->links()}}
-        </div>
+        {{ $posts->links() }}
     </div>
-
+</div>

--- a/resources/views/partials/_search_navigation.blade.php
+++ b/resources/views/partials/_search_navigation.blade.php
@@ -1,10 +1,7 @@
-
-    <div class="panel">
+<div class="panel">
     <p class="panel-tabs panel-tags">
-
         @foreach($tags as $tag)
-            <a href="">{{$tag->name}}</a>
+            <a href="">{{ $tag->name }}</a>
         @endforeach
     </p>
-    </div>
-
+</div>

--- a/resources/views/partials/_sidebar.blade.php
+++ b/resources/views/partials/_sidebar.blade.php
@@ -1,4 +1,5 @@
 <div class="column is-one-quarter">
-    @include('partials/widgets/_house-rankings')
-    @include('partials/widgets/_user-rankings')
+    @include('partials.widgets._house-rankings')
+
+    @include('partials.widgets._user-rankings')
 </div>

--- a/resources/views/partials/minis/_notifications.blade.php
+++ b/resources/views/partials/minis/_notifications.blade.php
@@ -1,8 +1,8 @@
-@if(count($errors))
+@if($errors->any())
     @foreach($errors->all() as $error)
         <div class="notification is-danger">
             <button class="delete"></button>
-            {{$error}}
+            {{ $error }}
         </div>
     @endforeach
 @endif
@@ -10,13 +10,13 @@
 @if(Session::has('success'))
     <div class="notification is-primary">
         <button class="delete"></button>
-        {{Session::get('success')}}
+        {{ Session::get('success') }}
     </div>
 @endif
 
 @if(Session::has('error'))
     <div class="notification is-danger">
         <button class="delete"></button>
-        {{Session::get('error')}}
+        {{ Session::get('error') }}
     </div>
 @endif

--- a/resources/views/partials/minis/_post-admin-controls.blade.php
+++ b/resources/views/partials/minis/_post-admin-controls.blade.php
@@ -1,12 +1,10 @@
 <div class="columns" style="margin-bottom:10px">
     <div class="column is-3" style="position: relative">
-        <i class="enable-admin-controls is-warning fa fa-user-md fa-2x">
+        <i class="enable-admin-controls is-warning fa fa-user-md fa-2x"></i>
 
-        </i>
         <ul class="admin-controls">
-            <li data-id="{{$post->id}}" class="admin-control btn-admin-control-remove">
-                <i class="fa fa-remove"></i>
-                remove this post
+            <li data-id="{{ $post->id }}" class="admin-control btn-admin-control-remove">
+                <i class="fa fa-remove"></i> remove this post
             </li>
         </ul>
     </div>

--- a/resources/views/partials/minis/_search.blade.php
+++ b/resources/views/partials/minis/_search.blade.php
@@ -2,6 +2,7 @@
     <p class="control">
         <input class="input" type="text" placeholder="Search the forum...">
     </p>
+
     <p class="control">
         <a class="button is-info">
             <i class="fa fa-2x fa-search"></i>

--- a/resources/views/partials/minis/_single-post.blade.php
+++ b/resources/views/partials/minis/_single-post.blade.php
@@ -3,17 +3,15 @@
         <figure class="media-type media-left media-question">
             <img src="{{ asset('img/icons/question.png') }}" alt="">
         </figure>
+
         <div class="media-content">
             <div class="content  media-post">
-                <p>
-                    <strong>{{ $post->author->name }}</strong>
-                </p>
-                <h4 class="title is-4">{{ $post->title }}</h4>
-                <p>{!! $post->content !!}
+                <p><strong>{{ $post->author->name }}</strong></p>
 
-                </p>
+                <h4 class="title is-4">{{ $post->title }}</h4>
+
+                <p>{!! $post->content !!}</p>
             </div>
         </div>
     </article>
-
 </div>

--- a/resources/views/partials/minis/_vote-group.blade.php
+++ b/resources/views/partials/minis/_vote-group.blade.php
@@ -1,27 +1,26 @@
-    <div class="vote-group is-pulled-right">
+<div class="vote-group is-pulled-right">
+    @unless($post->isYours() || $post->userHasVoted())
+        <span class="fa fa-arrow-up fa-2x" onclick="event.preventDefault();
+            $(this).closest('.button-group').find('.vote-form .vote-type').val('up');
+            $(this).closest('.button-group').find('.vote-form').submit();" >
+        </span>
+    @endunless
 
-        @unless($post->isYours() || $post->userHasVoted())
-            <span class="fa fa-arrow-up fa-2x" onclick="event.preventDefault();
-                $(this).closest('.button-group').find('.vote-form .vote-type').val('up');
-                $(this).closest('.button-group').find('.vote-form').submit();" >
-            </span>
-        @endunless
-        <span class="tag is-medium is-dark">{{$post->getVotesTotal()}} </span>
-        @unless($post->isYours() || $post->userHasVoted())
-            <span class="fa fa-arrow-down fa-2x " onclick="event.preventDefault();
-               $(this).closest('.button-group').find('.vote-form .vote-type').val('down');
-               $(this).closest('.button-group').find('.vote-form').submit();">
-            </span>
-        @endunless
+    <span class="tag is-medium is-dark">{{ $post->getVotesTotal() }}</span>
 
+    @unless($post->isYours() || $post->userHasVoted())
+        <span class="fa fa-arrow-down fa-2x " onclick="event.preventDefault();
+           $(this).closest('.button-group').find('.vote-form .vote-type').val('down');
+           $(this).closest('.button-group').find('.vote-form').submit();">
+        </span>
+    @endunless
 
-        @if($post->userHasVoted())
-            voted
-        @endif
-    </div>
+    @if($post->userHasVoted())
+        voted
+    @endif
+</div>
 
-    <form class="vote-form" data-vote="null" action="{{ action('PostController@vote', $post->id) }}" method="POST" style="display: none;">
-
-        <input type="hidden" name="vote" class="vote-type" value="">
-        {{ csrf_field() }}
-    </form>
+<form class="vote-form" data-vote="null" action="{{ action('PostController@vote', $post) }}" method="POST" style="display: none;">
+    <input type="hidden" name="vote" class="vote-type" value="">
+    {{ csrf_field() }}
+</form>

--- a/resources/views/partials/widgets/_house-rankings.blade.php
+++ b/resources/views/partials/widgets/_house-rankings.blade.php
@@ -1,17 +1,16 @@
+<div class="content">
+    <h3> <i class="fa fa-home"></i> House rankings </h3>
+        <div class="content">
+            <table class="table">
+                <thead>
+                <tr>
+                    <th>Pos</th>
+                    <th>House</th>
+                    <th>Points</th>
+                </tr>
+                </thead>
 
-    <div class="content">
-        <h3> <i class="fa fa-home"></i> House rankings </h3>
-            <div class="content">
-                <table class="table">
-                    <thead>
-                    <tr>
-                        <th>Pos</th>
-                        <th>House</th>
-                        <th>Points</th>
-                    </tr>
-                    </thead>
-
-                    <tbody>
+                <tbody>
                     @foreach($houses as $house)
                         <tr>
                             <td>{{ $house->id }}</td>
@@ -19,8 +18,7 @@
                             <td>{{ $house->pointsSum() }}</td>
                         </tr>
                     @endforeach
-                    </tbody>
-                </table>
-
-            </div>
+                </tbody>
+            </table>
+        </div>
     </div>

--- a/resources/views/partials/widgets/_user-rankings.blade.php
+++ b/resources/views/partials/widgets/_user-rankings.blade.php
@@ -1,17 +1,16 @@
-
+<div class="content">
+    <h3> <i class="fa fa-user"></i> User rankings </h3>
     <div class="content">
-        <h3> <i class="fa fa-user"></i> User rankings </h3>
-        <div class="content">
-            <table class="table">
-                <thead>
-                <tr>
-                    <th>Pos</th>
-                    <th>User</th>
-                    <th>Points</th>
-                </tr>
-                </thead>
+        <table class="table">
+            <thead>
+            <tr>
+                <th>Pos</th>
+                <th>User</th>
+                <th>Points</th>
+            </tr>
+            </thead>
 
-                <tbody>
+            <tbody>
                 @foreach($rankedUsers as $user)
                     <tr>
                         <td>{{ 1 }}</td>
@@ -19,8 +18,7 @@
                         <td>{{ $user->pointsSum() }}</td>
                     </tr>
                 @endforeach
-                </tbody>
-            </table>
-
-        </div>
+            </tbody>
+        </table>
     </div>
+</div>

--- a/resources/views/posts/create-answer.blade.php
+++ b/resources/views/posts/create-answer.blade.php
@@ -1,16 +1,17 @@
-@extends('layouts/app')
+@extends('layouts.app')
 
 @section('content')
     <div class="container main-content">
         <div class="columns content">
             <div class="column is-three-quarters">
-                @include('partials/minis/_single-post')
+                @include('partials.minis._single-post')
 
                 <h2 class="is-2">Your answer</h2>
-                <form method="POST" action="{{action('PostController@store')}}">
 
-                    <input type="hidden" name="question_id" value="{{$post->id}}">
-                    <input type="hidden" name="title" value="reply:{{$post->title}}">
+                <form method="POST" action="{{ action('PostController@store') }}">
+                    <input type="hidden" name="question_id" value="{{ $post->id }}">
+                    <input type="hidden" name="title" value="reply:{{ $post->title }}">
+
                     {{ csrf_field() }}
 
                     <div class="field">
@@ -18,14 +19,12 @@
                             <textarea class="textarea tinymce" name="content"></textarea>
                         </p>
                     </div>
+
                     <button class="button is-primary" type="submit">Submit</button>
                 </form>
-
             </div>
 
-            @include('partials/_sidebar')
-
+            @include('partials._sidebar')
         </div>
     </div>
-
 @endsection

--- a/resources/views/posts/create.blade.php
+++ b/resources/views/posts/create.blade.php
@@ -1,20 +1,20 @@
 @extends('layouts.app')
 
 @section('content')
-
     <div class="container main-content">
-
         <div class="content">
             <div class="columns">
                 <div class="column is-offset-two-thirds is-one-third panel is-pulled-right">
                     <p class="panel-heading">
                         How to ask questions!
                     </p>
+
                     <div class="panel-block">
                         <ul>
                             <li>
                                 First <strong> be sure your question hasn't already been posted. </strong> Use the search function to verify this.
                             </li>
+
                             <li>
                                 <strong> Be specific to your question. </strong> Give as much information as you can. Use links to sandbox
                                 environments (codepen.io for example) to illustrate the problem you are dealing with.
@@ -23,43 +23,48 @@
                     </div>
                 </div>
             </div>
+
             <form method="post" action="{{ action('PostController@store') }}">
                 {{ csrf_field() }}
+
                 <div class="field">
                     <label class="label">Title</label>
                     <p class="control">
                         <input type="text" placeholder="Please be specific about your question" class="input" name="title">
                     </p>
                 </div>
+
                 <div class="field">
-                    <label class="label">Question</label>
-                    <textarea name="content" id="" style="min-height:250px" class="textarea tinymce"></textarea>
+                    <label class="label" for="content">Question</label>
+                    <textarea name="content" id="content" style="min-height:250px" class="textarea tinymce"></textarea>
                 </div>
+
                 <div class="field">
                     <label class="label">Add tags</label>
                     <div class="field-body">
                         <div class="field is-narrow">
                             <div class="control">
                                 @foreach($tags as $tag)
-                                <label class="checkbox-inline">
-                                    <input type="checkbox" name="tag[]" value="{{$tag->id}}">
-                                    {{$tag->name}}
-                                </label>
+                                    <label class="checkbox-inline">
+                                        <input type="checkbox" name="tag[]" value="{{ $tag->id }}">
+                                        {{ $tag->name }}
+                                    </label>
                                 @endforeach
                             </div>
                         </div>
                     </div>
                 </div>
+
                 <div class="field is-grouped">
                     <p class="control">
                         <button class="button is-primary">Submit</button>
                     </p>
+
                     <p class="control">
-                        <a class="button is-link" href="/">cancel</a>
+                        <a class="button is-link" href="{{ route('home') }}">cancel</a>
                     </p>
                 </div>
             </form>
         </div>
     </div>
-
 @endsection

--- a/resources/views/posts/edit-answer.blade.php
+++ b/resources/views/posts/edit-answer.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts/app')
+@extends('layouts.app')
 
 @section('content')
     <div class="container main-content">
@@ -10,25 +10,25 @@
                             <img src="{{ asset('img/icons/question.png') }}" alt="">
                         </figure>
                         <div class="media-content">
-                            <div class="content  media-post">
+                            <div class="content media-post">
                                 <p>
                                     <strong>{{ $post->parent->author->name }}</strong>
                                 </p>
-                                <h4 class="title is-4">{{ $post->parent->title }}</h4>
-                                <p>{!! $post->parent->content !!}
 
-                                </p>
+                                <h4 class="title is-4">{{ $post->parent->title }}</h4>
+
+                                <p>{!! $post->parent->content !!}</p>
                             </div>
                         </div>
                     </article>
-
                 </div>
 
                 <h2 class="is-2">Your answer</h2>
-                <form method="POST" action="{{action('PostController@updateAnswer', $post->id)}}">
+                <form method="POST" action="{{ action('PostController@updateAnswer', $post) }}">
                     <input type="hidden" name="_method" value="put">
-                    <input type="hidden" name="question_id" value="{{$post->id}}">
-                    <input type="hidden" name="title" value="reply:{{$post->title}}">
+                    <input type="hidden" name="question_id" value="{{ $post->id }}">
+                    <input type="hidden" name="title" value="reply:{{ $post->title }}">
+
                     {{ csrf_field() }}
 
                     <div class="field">
@@ -36,19 +36,17 @@
                             <textarea class="textarea tinymce" name="content">{{$post->content}}</textarea>
                         </p>
                     </div>
+
                     <button class="button is-primary" type="submit">Submit</button>
                 </form>
-
             </div>
 
             <div class="column is-one-quarter">
                 <div class="content top-ranking">
                     <h3> House rankings </h3>
-                    @include('partials/_house-rankings')
+                    @include('partials._house-rankings')
                 </div>
             </div>
-
         </div>
     </div>
-
 @endsection

--- a/resources/views/posts/edit.blade.php
+++ b/resources/views/posts/edit.blade.php
@@ -1,23 +1,24 @@
 @extends('layouts.app')
 
 @section('content')
-
     <div class="container main-content">
-
         <div class="content">
-            <form method="post" action="{{ action('PostController@update', $post->id) }}">
+            <form method="post" action="{{ action('PostController@update', $post) }}">
                 {{ csrf_field() }}
+
                 <input type="hidden" name="_method" value="put">
                 <div class="field">
                     <label class="label">Title</label>
                     <p class="control">
-                        <input type="text" placeholder="Please be specific about your question" class="input" name="title" value="{{$post->title}}">
+                        <input type="text" placeholder="Please be specific about your question" class="input" name="title" value="{{ $post->title }}">
                     </p>
                 </div>
+
                 <div class="field">
                     <label class="label">Question</label>
-                    <textarea name="content" id="" cols="30" rows="10" class="textarea tinymce">{{$post->content}}</textarea>
+                    <textarea name="content" id="" cols="30" rows="10" class="textarea tinymce">{{ $post->content }}</textarea>
                 </div>
+
                 <div class="field">
                     <label class="label">Add tags</label>
                     <div class="field-body">
@@ -25,18 +26,20 @@
                             <div class="control">
                                 @foreach($tags as $tag)
                                     <label class="checkbox-inline">
-                                        <input type="checkbox" name="tag[]" value="{{$tag->id}}" {{$post->tags->contains($tag->id) ? 'checked' : ''}}>
-                                        {{$tag->name}}
+                                        <input type="checkbox" name="tag[]" value="{{ $tag->id }}" {{ $post->tags->contains($tag->id) ? 'checked' : '' }}>
+                                        {{ $tag->name }}
                                     </label>
                                 @endforeach
                             </div>
                         </div>
                     </div>
                 </div>
+
                 <div class="field is-grouped">
                     <p class="control">
                         <button class="button is-primary">Submit</button>
                     </p>
+
                     <p class="control">
                         <button class="button is-link">cancel</button>
                     </p>
@@ -44,5 +47,4 @@
             </form>
         </div>
     </div>
-
 @endsection

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -1,16 +1,13 @@
-@extends('layouts/app')
+@extends('layouts.app')
 
 @section('content')
+    <div class="container main-content">
+        <div class="columns">
+            <div class="column is-three-quarters">
+                 @include('partials._post')
+            </div>
 
-
-<div class="container main-content">
-    <div class="columns">
-        <div class="column is-three-quarters">
-             @include('partials/_post')
+            @include('partials._sidebar')
         </div>
-
-        @include('partials/_sidebar')
     </div>
-</div>
-
 @endsection

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -4,7 +4,7 @@
     <div class="container main-content">
         <div class="columns">
             <div class="column is-three-quarters">
-                <a href="{{route('post.create')}}" class="button ask-question is-pulled-right is-primary">Ask question</a>
+                <a href="{{ route('post.create') }}" class="button ask-question is-pulled-right is-primary">Ask question</a>
                 <posts></posts>
             </div>
 
@@ -13,10 +13,7 @@
                     <h3> House rankings </h3>
                     <house-rankings></house-rankings>
                 </div>
-
             </div>
-
         </div>
-
     </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,7 +11,7 @@
 |
 */
 
-Route::get('/', 'HomeController@index');
+Route::get('/', 'HomeController@index')->name('home');
 
 Auth::routes();
 


### PR DESCRIPTION
This pull request applies some consistency across the views. Some things that I fixed:

- [x] `{{$something}}` -> `{{ $something }}` (note the extra spaces around the variable).
- [x] Add line break after large(ish) blocks of HTML to make it more readable.
- [x] Applied the style `folder.view-name` everywhere instead of `folder/view-name` in some places.
- [x] Named the route at `/` (`home`) and linked to it in the navigation bar.