### PR TITLE
Fix travis and phpunit configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,8 @@ php:
 before_script:
   - composer install --no-interaction --no-scripts
 
+env:
+  - APP_KEY=base64:oKkca01Gaxi9n+4iJlF6VL1QIHp49Ln6VTa6N61O4Ws=
+
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,12 @@
 language: php
-php:
-  - '5.6'
-  - '7.0'
-  - '7.1'
 
-install:
-  - travis_retry composer install --no-interaction --prefer-source
+php:
+  - 5.6
+  - 7.0
+  - 7.1
+
+before_script:
+  - composer install --no-interaction
+
+script:
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.1
 
 before_script:
-  - composer install --no-interaction
+  - composer install --no-interaction --no-scripts
 
 script:
   - vendor/bin/phpunit

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,8 @@
     </filter>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="QUEUE_DRIVER" value="sync"/>


### PR DESCRIPTION
We'll explicitly run the `phpunit` executable in the `vendor/bin` directory to ensure we're running the right version of phpunit on Travis' container. 

Setting the `DB_CONNECTION` and `DB_DATABASE` environment variables in `phpunit.xml` to `sqlite` and `:memory:` respectively means we'll use an [sqlite](https://www.sqlite.org/) (in-memory) database loaded into memory whenever we're running the tests.

Before this is merged, can you (@Feddman and/or @TheJjokerR) make sure this works on your guys' machines? 