### PR TITLE
Fix validation for registration

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -53,7 +53,7 @@ class RegisterController extends Controller
             'password' => 'required|min:6|confirmed',
 
             'level' => 'required|between:0,100',
-            'house' => 'required|exists:house_roles,id'
+            'house' => 'required|exists:houses,id'
         ]);
     }
 


### PR DESCRIPTION
When registering a new user, the validation should check if the passed in `house` request parameter exists on the `houses` table, instead of on the `house_roles` table.  A new `HouseRole` is automatically created when registering a new user.