### PR TITLE
new responsive header

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -38,6 +38,29 @@ $('document').ready(function(){
       }
     });
 
+    $('.toggle-options').on('click', function () {
+      $('.header-nav').removeClass('is-active')
+      $('.toggle-header-nav').removeClass('is-active')
+
+      $('.options-dropdown').toggleClass('is-active')
+      $(this).toggleClass('is-active')
+    })
+
+    $('.toggle-header-nav').on('click', function () {
+      $('.options-dropdown').removeClass('is-active')
+      $('.toggle-options').removeClass('is-active')
+
+      $('.header-nav').toggleClass('is-active')
+      $(this).toggleClass('is-active')
+    })
+
+    $('.hero, .main-content').on('click', function () {
+      $('.options-dropdown').removeClass('is-active')
+      $('.toggle-options').removeClass('is-active')
+      $('.header-nav').removeClass('is-active')
+      $('.toggle-header-nav').removeClass('is-active')
+    })
+
     $(".delete").on('click', function(){
        $(this).parent().slideToggle();
     });

--- a/resources/assets/sass/_header.scss
+++ b/resources/assets/sass/_header.scss
@@ -1,0 +1,118 @@
+a.nav-item {
+  // color: rgba(white, 0.8);
+  position: relative;
+  &:hover {
+    color: white;
+  }
+}
+
+.header {
+  background: $header-bg;
+  position: relative;
+  width: 100%;
+  height: $header-height;
+  z-index: 99;
+  .toggle-header-nav {
+    &.is-active {
+      background: $hoverNav;
+      .icon {
+        color: white;
+      }
+    }
+  }
+  .container {
+    display: flex;
+    height: 100%;
+    position: relative;
+  }
+  .header-left, .header-right {
+    display: flex;
+    flex-direction: row;
+  }
+  .header-left {
+    justify-content: flex-start;
+  }
+  .header-right {
+    justify-content: flex-end;
+    flex-grow: 1;
+    .search-field {
+      width: 100%;
+    }
+  }
+  .header-search-field {
+    margin-bottom: 0;
+    flex-grow: 1;
+    form {
+      flex-grow: 1;
+      display: flex;
+    }
+    .header-search-control {
+      flex-grow: 1;
+      input {
+        flex-grow: 1;
+      }
+    }
+  }
+  .header-nav {
+    display: flex;
+    flex-direction: row;
+    background: $header-bg;
+    @media screen and (max-width: 768px) {
+      display: none;
+      flex-direction: column;
+      position: absolute;
+      bottom: 0;
+      transform: translateY(100%);
+      width: 100%;
+    }
+    &.is-active {
+      display: inherit;
+    }
+    li, a {
+      height: 100%;
+    }
+  }
+  .nav-item.is-tab {
+    border: 0;
+    // color: whitesmoke;
+    &:hover, &.is-active {
+      background: $hoverNav;
+      color: white;
+      border: 0;
+    }
+    .icon {
+      margin-right: 1rem;
+    }
+  }
+}
+
+
+.options-dropdown {
+  background: $hoverNav;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  transform: translateY(100%);
+  display: none;
+  &.is-active {
+    display: block;
+  }
+  .is-tab.nav-item {
+    justify-content: flex-start;
+    &:hover {
+      background: $header-bg;
+    }
+  }
+}
+
+.toggle-options {
+  &.has-notifications .icon {
+    color: $notifications;
+  }
+  &.is-active {
+    background-color: $hoverNav;
+    .icon {
+      color: white;
+    }
+  }
+}

--- a/resources/assets/sass/_variables.scss
+++ b/resources/assets/sass/_variables.scss
@@ -27,7 +27,12 @@ $line-height-base: 1.6;
 $text-color: #636b6f;
 
 // Navbar
-$navbar-default-bg: #fff;
+$navbar-default-bg: #222222;
+
+$header-bg: #222222;
+$notifications: #cb4437;
+$hoverNav: #000000;
+$header-height: 3em;
 
 // Buttons
 $btn-default-color: $text-color;

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -20,6 +20,30 @@ span.panel-heading{
   display: block;
 }
 
+.tag {
+  &.is-notification {
+    font-size: 10px;
+    padding: 1px 3px;
+    background: $notifications;
+    border-radius: 2px;
+    color: white;
+    font-size: 10px;
+    min-height: 13px;
+    line-height: 1.3;
+    border: 1px solid rgba(white, 0.2);
+    position: absolute;
+    top: 9px;
+    left: 4px;
+    text-align: right;
+    margin: 0 !important;
+    height: 12px;
+    min-width: 12px;
+  }
+}
+
+// header
+@import "header";
+
 // General classes
 .center-content{
   text-align: center
@@ -276,4 +300,3 @@ footer.main-footer {
   }
 
 }
-

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -25,7 +25,7 @@
 </head>
 <body>
     <div id="app">
-        <nav class="nav has-shadow">
+        <!-- <nav class="nav has-shadow">
             <div class="container">
                 <div class="nav-left">
                     <a href="{{ route('home') }}" class="nav-item">
@@ -82,7 +82,120 @@
                     </form>
                 </div>
             </div>
-        </nav>
+        </nav> -->
+
+        <div class="header">
+          <div class="container">
+            <div class="header-left">
+              <!-- Logo -->
+              <a href="{{ route('home') }}" class="nav-item">
+                  <img src="{{ asset('img/rc-fc.png') }}" alt="">
+              </a>
+              <!-- Hamburger menu -->
+              <a class="nav-item toggle-header-nav is-hidden-tablet">
+                <span class="icon">
+                  <i class="fa fa-bars"></i>
+                </span>
+              </a>
+              <!-- Nav menu -->
+              @if (Auth::guest())
+                <ul class="header-nav">
+                  <li><a href="{{ route('login') }}" class="nav-item is-tab">login</a></li>
+                  <li><a href="{{ route('register') }}" class="nav-item is-tab">register</a></li>
+                </ul>
+              @else
+                <ul class="header-nav">
+                  <li><a href="{{ action('HomeController@index') }}" class="nav-item is-tab {{ strpos(Request::path(), 'home') !== false ? "is-active" : "" }}">Knowledgebase</a></li>
+                  <li><a href="{{ action('HomeController@learn') }}" class="nav-item is-tab {{ strpos(Request::path(), 'learn') !== false ? 'is-active' : ''}} ">Learn</a></li>
+                  <li><a href="{{ action('HomeController@about') }}" class="nav-item is-tab {{ strpos(Request::path(), 'about') !== false ? 'is-active' : ''}}">Story</a></li>
+                </ul>
+              @endif
+            </div>
+
+            @if (Auth::guest())
+            @else
+
+              <div class="header-right">
+                <!-- Search bar -->
+
+                <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+                    {{ csrf_field() }}
+                </form>
+
+                <div class="field has-addons header-search-field is-hidden-mobile nav-item">
+                  <form action="{{action('PostController@search')}}">
+                      {{csrf_field()}}
+                    <p class="control header-search-control">
+                      <input class="input" name="query" type="text" placeholder="Search the forum...">
+                    </p>
+                    <p class="control">
+                      <button type="submit" class="button">
+                        <span class="icon">
+                          <i class="fa fa-search"></i>
+                        </span>
+                      </button>
+                    </p>
+                  </form>
+                </div>
+                <a href="{{ route('message.index') }}" class="nav-item is-tab is-hidden-mobile">
+                  <span class="tag is-progress is-notification">99+</span>
+                  <span class="icon is-marginless"><i class="fa fa-bell"></i></span>
+                </a>
+                <!-- Options button -->
+                <a class="nav-item toggle-options">
+                  <span class="icon"><i class="fa fa-cog"></i></span>
+                </a>
+                <!-- Options menu/dropdown -->
+                <ul class="options-dropdown">
+                  <!-- Mobile search bar -->
+                  <li class="is-hidden-tablet">
+                    <a class="nav-item">
+                      <div class="field has-addons header-search-field">
+                        <form action="{{action('PostController@search')}}">
+                            {{csrf_field()}}
+                          <p class="control header-search-control">
+                            <input class="input" name="query" type="text" placeholder="Search the forum...">
+                          </p>
+                          <p class="control">
+                            <button type="submit" class="button">
+                              <span class="icon">
+                                <i class="fa fa-search"></i>
+                              </span>
+                            </button>
+                          </p>
+                        </form>
+                      </div>
+                    </a>
+                  </li>
+                  <!-- Options nav -->
+                  <li><a class="nav-item is-tab is-hidden-tablet"><span class="icon"><i class="fa fa-home"></i></span>Home</a></li>
+                  {{-- <li><a class="nav-item is-tab">About</a></li> --}}
+
+                  <li>
+                    <a href="{{ route('message.index') }}" class="nav-item is-tab">
+                      <!-- Unread notification -->
+                      <span class="tag is-progress is-notification">99+</span>
+
+                      <span class="icon">
+                        <i class="fa fa-envelope"></i>
+                      </span>
+                      Inbox
+                    </a>
+                  </li>
+
+                  @if (\Auth::user()->isHeadMaster())
+                    <li><a  href="{{ route('dashboard') }}" class="nav-item is-tab"><span class="icon"><i class="fa fa-bar-chart"></i></span> Dashboard</a></li>
+                  @else
+                    <li><a href="{{ route('profile') }}" class="nav-item is-tab"><span class="icon"><i class="fa fa-user"></i></span> Profile</a></li>
+                  @endif
+                  <li><a onclick="event.preventDefault(), document.getElementById('logout-form').submit" href="{{ route('logout') }}" class="nav-item is-tab"><span class="icon"><i class="fa fa-sign-out"></i></span> Logout</a></li>
+                </ul>
+
+              </div>
+            @endif
+          </div>
+
+        </div>
 
         <section class="hero banner">
             <div class="hero-body">


### PR DESCRIPTION
The previous header couldn't be made responsive, Bulma responsive nav-menu only works with nav-right. Because of that the page navigation (on the left), doesn't get included into the mobile menu.

The header I made has 2 different toggles. One for options (inbox, logout etc.) and one for the main page navigation.

- The search bar gets stretched.
- Added a unread messages counter. Has to be implementen into the back-end yet.

The previous header is commented in-case I missed something.

That's about it.